### PR TITLE
Run PEP8 on content

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,10 +4,11 @@ import requests
 text_analytics_base_url = os.environ["BASE_URL"]
 subscription_key = os.environ["SUBSCRIPTION_KEY"]
 sentiment_api_url = text_analytics_base_url + "sentiment"
-documents = {'documents' : [
-  {'id': '1', 'language': 'en', 'text': 'I had a wonderful experience! The rooms were wonderful and the staff was helpful.'}
+documents = {'documents': [
+    {'id': '1', 'language': 'en',
+        'text': 'I had a wonderful experience! The rooms were wonderful and the staff was helpful.'}
 ]}
-headers   = {"Ocp-Apim-Subscription-Key": subscription_key}
-response  = requests.post(sentiment_api_url, headers=headers, json=documents)
+headers = {"Ocp-Apim-Subscription-Key": subscription_key}
+response = requests.post(sentiment_api_url, headers=headers, json=documents)
 sentiments = response.json()
 pprint(sentiments)


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.